### PR TITLE
Refactor Table Filter Functions

### DIFF
--- a/src/components/layout/ConfigPanel/property/Table/TableColumnForm.tsx
+++ b/src/components/layout/ConfigPanel/property/Table/TableColumnForm.tsx
@@ -11,6 +11,7 @@ import { Select } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Column } from '@/types/table';
+import { TABLE_FILTER_FUNCTION } from '@/constants/table';
 
 import { TableColumnList } from './TableColumnList';
 
@@ -119,16 +120,20 @@ export function TableColumnForm({
           >
             <SelectTrigger id='filterFn' className='w-full'>
               <SelectValue
-                defaultValue='includesString'
+                defaultValue={TABLE_FILTER_FUNCTION.INCLUDES}
                 placeholder='Select filter function'
               />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value='includesString'>Includes</SelectItem>
-              <SelectItem value='includesStringSensitive'>
+              <SelectItem value={TABLE_FILTER_FUNCTION.INCLUDES}>
+                Includes
+              </SelectItem>
+              <SelectItem value={TABLE_FILTER_FUNCTION.INCLUDES_CASE_SENSITIVE}>
                 Includes Case Sensitive
               </SelectItem>
-              <SelectItem value='equalsString'>Equals</SelectItem>
+              <SelectItem value={TABLE_FILTER_FUNCTION.EQUALS}>
+                Equals
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/constants/table.ts
+++ b/src/constants/table.ts
@@ -21,21 +21,27 @@ export const sampleRows = [
   },
 ];
 
+export const TABLE_FILTER_FUNCTION = {
+  EQUALS: 'equalsString',
+  INCLUDES: 'includesString',
+  INCLUDES_CASE_SENSITIVE: 'includesStringSensitive',
+};
+
 export const TABLE_SAMPLE_COLUMNS = JSON.stringify([
   {
     accessorKey: 'id',
     header: 'ID',
-    filterFn: 'equalsString',
+    filterFn: TABLE_FILTER_FUNCTION.EQUALS,
   },
   {
     accessorKey: 'task',
     header: 'Task',
-    filterFn: 'includesString',
+    filterFn: TABLE_FILTER_FUNCTION.INCLUDES,
   },
   {
     accessorKey: 'completed',
     header: 'Completed',
-    filterFn: 'equalsString',
+    filterFn: TABLE_FILTER_FUNCTION.EQUALS,
   },
 ]);
 

--- a/src/hooks/useLoadTableData.tsx
+++ b/src/hooks/useLoadTableData.tsx
@@ -15,6 +15,7 @@ import { useComponentActions } from '@/hooks/useComponentActions';
 import { TableRowData } from '@/types/table';
 import { Column } from '@/types/table';
 import { selectedComponentAtom } from '@/atoms/component';
+import { TABLE_FILTER_FUNCTION } from '@/constants/table';
 
 export function useLoadTableData(columns: Column[]) {
   const selectedComponent = useAtomValue(selectedComponentAtom);
@@ -74,7 +75,7 @@ export function useLoadTableData(columns: Column[]) {
             .slice(1)
             .replace(/([A-Z])/g, ' $1')
             .trim(),
-        filterFn: '',
+        filterFn: TABLE_FILTER_FUNCTION.INCLUDES,
       }));
 
       if (columns.length > 0) {


### PR DESCRIPTION
Constantize table filter functions and set default filter functions as `includesString` for table columns loaded from API